### PR TITLE
Add simple pwstore-fast program to generate hashed passwords

### DIFF
--- a/pwstore-fast.cabal
+++ b/pwstore-fast.cabal
@@ -20,6 +20,9 @@ Build-type:          Simple
 Extra-source-files:  README.md
 Cabal-version:       >=1.2
 
+flag pwstoreprog
+  Default:         True
+  description:     Build the pwstore program
 
 Library
   Exposed-modules: Crypto.PasswordStore
@@ -27,4 +30,15 @@ Library
                    base64-bytestring >= 0.1,
                    cryptohash >= 0.6, random >= 1
   ghc-options:     -Wall
-  
+
+Executable         pwstore-fast
+  if flag(pwstoreprog)
+    Buildable: True
+  else
+    Buildable: False
+
+  Main-is:         pwstore.hs
+  Other-modules:   Paths_pwstore_fast
+  Build-depends:   base == 4.*, cmdargs == 0.7.*, utf8-string == 0.3.*
+  Ghc-options:     -Wall -fno-warn-missing-fields
+  Extensions:      DeriveDataTypeable, RecordWildCards

--- a/pwstore-fast.cabal
+++ b/pwstore-fast.cabal
@@ -39,6 +39,6 @@ Executable         pwstore-fast
 
   Main-is:         pwstore.hs
   Other-modules:   Paths_pwstore_fast
-  Build-depends:   base == 4.*, cmdargs == 0.7.*, utf8-string == 0.3.*
+  Build-depends:   base == 4.*, cmdargs == 0.7.*
   Ghc-options:     -Wall -fno-warn-missing-fields
   Extensions:      DeriveDataTypeable, RecordWildCards

--- a/pwstore.hs
+++ b/pwstore.hs
@@ -1,0 +1,72 @@
+module Main (main) where
+
+import Paths_pwstore_fast (version)
+
+import Control.Applicative ((*>), (<*))
+import Control.Monad (when)
+import Crypto.PasswordStore (genSaltIO, makeSalt, makePasswordSalt)
+import qualified Data.ByteString.Char8 as B
+import Data.Version (showVersion)
+import System.Console.CmdArgs
+import System.Environment (getProgName)
+import System.Exit (exitFailure)
+import System.IO (stdin, stdout, hFlush, hIsTerminalDevice, hSetEcho)
+
+-- | Command line options.
+data Options = Options { strength :: Int
+                       , password :: Maybe String
+                       , salt :: Maybe String
+                       }
+             deriving (Show, Data, Typeable)
+
+-- | Build the CmdArgs option parser.
+options :: String -> Mode (CmdArgs Options)
+options progname =
+  cmdArgsMode_ $ record Options{}
+    [ strength := 12
+      += help "Strength value, default is 12"
+    , password := Nothing
+      += help "Password to hash, will be asked for if missing"
+      += typ "PASSWORD"
+      += explicit
+      += name "password"
+    , salt := Nothing
+      += help "Hash salt, a random salt is used if missing"
+      += typ "SALT"
+      += explicit
+      += name "salt"
+    ]
+    += program progname
+    += summary (progname ++ " " ++ showVersion version)
+    += details ["Generates salted password hashes in the pwstore format."]
+    += helpArg []
+    += versionArg []
+
+-- | IO action that reads a password from standard input.  Terminal
+-- echoing is disabled while reading.
+getPassword :: IO B.ByteString
+getPassword = do
+  isTerminal <- hIsTerminalDevice stdin
+  if isTerminal
+     then putStr "Password: "
+          *> hFlush stdout
+          *> hSetEcho stdin False
+          *> B.getLine
+          <* hSetEcho stdin True
+          <* putStrLn ""
+    else B.getLine
+
+main :: IO ()
+main = do progname <- getProgName
+          Options{..} <- cmdArgsRun . options $ progname
+
+          when (strength < 1) $
+            putStrLn "Strength must be positive" >> exitFailure
+
+          when (maybe False ((< 8) . length) salt) $
+            putStrLn "Salt must be 8 characters or longer." >> exitFailure
+
+          password' <- maybe getPassword (return . B.pack) password
+          salt' <- maybe genSaltIO (return . makeSalt . B.pack) salt
+
+          B.putStrLn $ makePasswordSalt password' salt' strength

--- a/pwstore.hs
+++ b/pwstore.hs
@@ -38,35 +38,39 @@ options progname =
     ]
     += program progname
     += summary (progname ++ " " ++ showVersion version)
-    += details ["Generates salted password hashes in the pwstore format."]
+    += details [ "The " ++ progname ++ " program generates salted password hashes suitable for storage."
+               , ""
+               , "Note, this program assumes the use of ASCII characters in salts and passwords."
+               ]
     += helpArg []
     += versionArg []
 
 -- | IO action that reads a password from standard input.  Terminal
 -- echoing is disabled while reading.
 getPassword :: IO B.ByteString
-getPassword = do
-  isTerminal <- hIsTerminalDevice stdin
-  if isTerminal
-     then putStr "Password: "
-          *> hFlush stdout
-          *> hSetEcho stdin False
-          *> B.getLine
-          <* hSetEcho stdin True
-          <* putStrLn ""
-    else B.getLine
+getPassword =
+  do isTerminal <- hIsTerminalDevice stdin
+     if isTerminal
+       then putStr "Password: "
+            *> hFlush stdout
+            *> hSetEcho stdin False
+            *> B.getLine
+            <* hSetEcho stdin True
+            <* putStrLn ""
+       else B.getLine
 
 main :: IO ()
-main = do progname <- getProgName
-          Options{..} <- cmdArgsRun . options $ progname
+main =
+  do progname <- getProgName
+     Options{..} <- cmdArgsRun . options $ progname
 
-          when (strength < 1) $
-            putStrLn "Strength must be positive" >> exitFailure
+     when (strength < 1) $
+       putStrLn "Strength must be positive" >> exitFailure
 
-          when (maybe False ((< 8) . length) salt) $
-            putStrLn "Salt must be 8 characters or longer." >> exitFailure
+     when (maybe False ((< 8) . length) salt) $
+       putStrLn "Salt must be 8 characters or longer." >> exitFailure
 
-          password' <- maybe getPassword (return . B.pack) password
-          salt' <- maybe genSaltIO (return . makeSalt . B.pack) salt
+     password' <- maybe getPassword (return . B.pack) password
+     salt' <- maybe genSaltIO (return . makeSalt . B.pack) salt
 
-          B.putStrLn $ makePasswordSalt password' salt' strength
+     B.putStrLn $ makePasswordSalt password' salt' strength


### PR DESCRIPTION
These changes adds a pwstore-fast program that can be used to generate password hashes from the command line.  This may be handy to have available on a deployment site where no ghci is available.  Currently the cabal file is building the program automatically – pulling in a dependency on cmdargs in the process.  This may not be the best idea so if you decide to pull; feel free to change the flag default to false.

If needed, it should be simple to make a corresponding program for the pure version of pwstore.

Example usage (note, the password prompt turns off input echoing):

```
rycee@sigma:~$ pwstore-fast 
Password: 
sha256|12|/uGuhYRb8YRTUJLy9QrJAg==|+c6pLA7PzlLXoRfBbNyBetqDZ2i7tNKb6LaASCposzo=
rycee@sigma:~$ pwstore-fast --password hunter2
sha256|12|TPEz2kCfHFBB8qvBVQsgrQ==|Rl8SdPX3bDGA1Yk+r3f6c3sD4d64cXiJePBsDA4W39w=
rycee@sigma:~$ pwstore-fast --salt 72cd18b5ebfe6e96 --password hunter2
sha256|12|NzJjZDE4YjVlYmZlNmU5Ng==|M17VU2ciK8VaKyyDfVeGHS5eiLAuiStg/Y647B+Y4aE=
rycee@sigma:~$ pwstore-fast --help
pwstore-fast 2.1

pwstore-fast [OPTIONS]

Common flags:
  -s --strength=INT       Strength value, default is 12
     --password=PASSWORD  Password to hash, will be asked for if missing
     --salt=SALT          Hash salt, a random salt is used if missing
  -? --help               Display help message
  -V --version            Print version information

The pwstore-fast program generates salted password hashes suitable for storage.

Note, this program assumes the use of ASCII characters in salts and passwords.
rycee@sigma:~$
```
