### PR TITLE
Pbkdf2

### DIFF
--- a/pwstore-fast/Crypto/PasswordStore.hs
+++ b/pwstore-fast/Crypto/PasswordStore.hs
@@ -181,7 +181,7 @@ int i = let str = BL.unpack . Binary.encode $ i
                 
 -- | A convenience function to XOR two @ByteString@ together.
 xor' :: ByteString -> ByteString -> ByteString
-xor' b1 b2 = BS.pack $ BS.zipWith (.|.) b1 b2
+xor' b1 b2 = BS.pack $ BS.zipWith xor b1 b2
 
 -- | Generate a 'Salt' from 128 bits of data from @\/dev\/urandom@, with the
 -- system RNG as a fallback. This is the function used to generate salts by

--- a/pwstore-fast/Crypto/PasswordStore.hs
+++ b/pwstore-fast/Crypto/PasswordStore.hs
@@ -165,7 +165,7 @@ pbkdf2 password (SaltBS salt) c =
     -- The @f@ function, as defined in the spec.
     -- It calls @u@ under the hood.
     f :: Int -> ByteString
-    f i = let u1 = salt `B.append` int i
+    f i = let u1 = hmacSHA256 password (salt `B.append` int i)
       -- Using the ST Monad, for maximum performance.
       in runST $ do
           u <- newSTRef u1

--- a/pwstore-fast/Crypto/PasswordStore.hs
+++ b/pwstore-fast/Crypto/PasswordStore.hs
@@ -169,7 +169,7 @@ pbkdf2 password (SaltBS salt) c =
       -- Using the ST Monad, for maximum performance.
       in runST $ do
           u <- newSTRef u1
-          forM_ [2 .. c - 1] $ \_ ->
+          forM_ [2 .. c] $ \_ ->
             modifySTRef' u (\msg -> msg `xor'` hmacSHA256 password msg)
           readSTRef u
 

--- a/pwstore-fast/pwstore-fast.cabal
+++ b/pwstore-fast/pwstore-fast.cabal
@@ -29,6 +29,7 @@ Library
   Exposed-modules: Crypto.PasswordStore
   Build-depends:   base >= 4, base < 5, bytestring >= 0.9,
                    base64-bytestring >= 0.1,
+                   binary >= 0.5,
                    cryptohash >= 0.6, random >= 1
   ghc-options:     -Wall
   

--- a/pwstore-fast/pwstore-fast.cabal
+++ b/pwstore-fast/pwstore-fast.cabal
@@ -30,6 +30,7 @@ Library
   Build-depends:   base >= 4, base < 5, bytestring >= 0.9,
                    base64-bytestring >= 0.1,
                    binary >= 0.5,
+                   SHA >= 1.6.1,
                    cryptohash >= 0.6, random >= 1
   ghc-options:     -Wall
   


### PR DESCRIPTION
Hi!

First of all, I do really apologise for the big PR, I really wanted to make a tinier one, but a lot of function I've introduced wouldn't have made sense in the overall picture. Let me try to explain what this patch tries to solve.

A week ago I had the need of migrating some password from a legacy webapp of mine, written in Django, in a new REST server written in Haskell. The first idea I had was to use your library to compute the very same "auth string" that Django generates, in order to have all the password migrated for free. Despite your library is awesome, I found it limiting, because:
- It was using pbkdf1, whereas Django was using pbkdf2
- It was not possible to explicitly set the strength for the password, because the value you feed in is automatically used to compute the strength as 2^strength.

In case you are wondering, the following changes does not break the API, so they are _fully backward compatible_. This means that, if you merge this patch now, nobody will have his password routine broke, which is a big deal because also Snap is using your library for his `Auth` snaplet. But in a nutshell, what does this PR ship?
- A sane, fast and RFC compliant pbkdf2 algorithm. On my old 2009 macbook the generation for a new password takes 300ms with 10000 iterations, on my new 2011 macbook just 160ms. I've tested the functions
  against the RFC vectors, and it's generating indeed the correct results.
- It exposes helper functions which allow the programmer to have the full control over the password generation, in terms of which algorithm to use (they can now choose between pbkdf1 or pbkdf2), the number of iterations and so on and so forth.
- As I told you, it doesn't brake existing code; The "old" functions are still there and takes sensible defaults. As a proof for that, I've run `Tests.hs` and everything was fine.
- The code is extremely well documented, I've really tried to keep up with existing coding style and documentations.

Overall, I really think it's a good patch; I know, it basically scratches my own itches, but it now gives more control to the programmer, just if he wants it. I had to use Galois' `SHA` library, which ships which a sane version of `hmac` function.

Last but not least, at the moment this is the _only_ SANE pbkdf2 algorithm on Hackage. There is another package, called pbkdf2 by Silkapp, but it's broken in the implementation, just looking at the code reveals it (for example the author is using `or` instead of appending in a couple of places), so I think this addition could be really helpful for the whole Haskell community!

I'm really sorry for the lengthy writeup, but I really think having a lot of information is definitely better than having none!
If you have any enquiry/concern please tell me, I can modify the code accordingly :)

Thanks!
Alfredo
